### PR TITLE
Add whitelist to make sure bump StackEdge version correctly

### DIFF
--- a/tools/VersionController/Models/VersionBumper.cs
+++ b/tools/VersionController/Models/VersionBumper.cs
@@ -6,7 +6,7 @@ using System.Management.Automation;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Tools.Common.Models;
-using VersionController.Netcore.Utilities;
+using VersionController.Utilities;
 
 namespace VersionController.Models
 {
@@ -297,7 +297,7 @@ namespace VersionController.Models
                                                    .Where(f => !f.Contains("Netcore") &&
                                                                !f.Contains("bin") &&
                                                                !f.Contains("dll-Help") &&
-                                                               (!f.Contains("Stack") || WhiteList.Contains(f)))
+                                                               !ModuleFilter.IsAzureStackModule(f))
                                                    .ToList();
                 foreach (var moduleManifestPath in moduleManifestPaths)
                 {

--- a/tools/VersionController/Models/VersionBumper.cs
+++ b/tools/VersionController/Models/VersionBumper.cs
@@ -6,6 +6,7 @@ using System.Management.Automation;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Tools.Common.Models;
+using VersionController.Netcore.Utilities;
 
 namespace VersionController.Models
 {
@@ -296,7 +297,7 @@ namespace VersionController.Models
                                                    .Where(f => !f.Contains("Netcore") &&
                                                                !f.Contains("bin") &&
                                                                !f.Contains("dll-Help") &&
-                                                               !f.Contains("Stack"))
+                                                               (!f.Contains("Stack") || WhiteList.Contains(f)))
                                                    .ToList();
                 foreach (var moduleManifestPath in moduleManifestPaths)
                 {

--- a/tools/VersionController/Models/VersionFileHelper.cs
+++ b/tools/VersionController/Models/VersionFileHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using VersionController.Netcore.Utilities;
+using VersionController.Utilities;
 
 namespace VersionController.Models
 {
@@ -66,7 +66,7 @@ namespace VersionController.Models
         public string ChangeLogPath => Directory.GetFiles(ProjectDirectory, "ChangeLog.md").FirstOrDefault();
 
         public List<string> AssemblyInfoPaths => Directory.GetFiles(SrcDirectory, "AssemblyInfo.cs", SearchOption.AllDirectories)
-                                                            .Where(f => (!f.Contains("Stack") || WhiteList.Contains(f)) && !f.Contains(".Test"))
+                                                            .Where(f => !ModuleFilter.IsAzureStackModule(f) && !f.Contains(".Test"))
                                                             .ToList();
 
         public string GalleryModuleDirectory => OutputModuleDirectory;

--- a/tools/VersionController/Models/VersionFileHelper.cs
+++ b/tools/VersionController/Models/VersionFileHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using VersionController.Netcore.Utilities;
 
 namespace VersionController.Models
 {
@@ -65,7 +66,7 @@ namespace VersionController.Models
         public string ChangeLogPath => Directory.GetFiles(ProjectDirectory, "ChangeLog.md").FirstOrDefault();
 
         public List<string> AssemblyInfoPaths => Directory.GetFiles(SrcDirectory, "AssemblyInfo.cs", SearchOption.AllDirectories)
-                                                            .Where(f => !f.Contains("Stack") && !f.Contains(".Test"))
+                                                            .Where(f => (!f.Contains("Stack") || WhiteList.Contains(f)) && !f.Contains(".Test"))
                                                             .ToList();
 
         public string GalleryModuleDirectory => OutputModuleDirectory;

--- a/tools/VersionController/Program.cs
+++ b/tools/VersionController/Program.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 using System.Reflection;
 using Tools.Common.Models;
 using VersionController.Models;
+using VersionController.Netcore.Utilities;
 
 namespace VersionController
 {
@@ -105,7 +106,7 @@ namespace VersionController
             foreach (var directory in _projectDirectories)
             {
                 var changeLogs = Directory.GetFiles(directory, "ChangeLog.md", SearchOption.AllDirectories)
-                                            .Where(f => (!f.Contains("Stack") || f.Contains("StackEdge")) && IsChangeLogUpdated(f))
+                                            .Where(f => (!f.Contains("Stack") || WhiteList.Contains(f)) && IsChangeLogUpdated(f))
                                             .Select(f => GetModuleManifestPath(Directory.GetParent(f).FullName))
                                             .Where(m => m.Contains(_moduleNameFilter))
                                             .ToList();
@@ -170,7 +171,7 @@ namespace VersionController
             foreach (var directory in _projectDirectories)
             {
                 var changeLogs = Directory.GetFiles(directory, "ChangeLog.md", SearchOption.AllDirectories)
-                                            .Where(f => !f.Contains("Stack"))
+                                            .Where(f => !f.Contains("Stack") || WhiteList.Contains(f))
                                             .Select(f => GetModuleManifestPath(Directory.GetParent(f).FullName))
                                             .Where(m => !string.IsNullOrEmpty(m) && m.Contains(_moduleNameFilter))
                                             .ToList();

--- a/tools/VersionController/Program.cs
+++ b/tools/VersionController/Program.cs
@@ -7,7 +7,7 @@ using System.Management.Automation;
 using System.Reflection;
 using Tools.Common.Models;
 using VersionController.Models;
-using VersionController.Netcore.Utilities;
+using VersionController.Utilities;
 
 namespace VersionController
 {
@@ -106,7 +106,7 @@ namespace VersionController
             foreach (var directory in _projectDirectories)
             {
                 var changeLogs = Directory.GetFiles(directory, "ChangeLog.md", SearchOption.AllDirectories)
-                                            .Where(f => (!f.Contains("Stack") || WhiteList.Contains(f)) && IsChangeLogUpdated(f))
+                                            .Where(f => !ModuleFilter.IsAzureStackModule(f) && IsChangeLogUpdated(f))
                                             .Select(f => GetModuleManifestPath(Directory.GetParent(f).FullName))
                                             .Where(m => m.Contains(_moduleNameFilter))
                                             .ToList();
@@ -171,7 +171,7 @@ namespace VersionController
             foreach (var directory in _projectDirectories)
             {
                 var changeLogs = Directory.GetFiles(directory, "ChangeLog.md", SearchOption.AllDirectories)
-                                            .Where(f => !f.Contains("Stack") || WhiteList.Contains(f))
+                                            .Where(f => !ModuleFilter.IsAzureStackModule(f))
                                             .Select(f => GetModuleManifestPath(Directory.GetParent(f).FullName))
                                             .Where(m => !string.IsNullOrEmpty(m) && m.Contains(_moduleNameFilter))
                                             .ToList();

--- a/tools/VersionController/Utilities/ModuleFilter.cs
+++ b/tools/VersionController/Utilities/ModuleFilter.cs
@@ -1,17 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing.Drawing2D;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace VersionController.Netcore.Utilities
+namespace VersionController.Utilities
 {
-    class WhiteList
+    class ModuleFilter
     {
-        public static bool Contains(String fileName)
+        public static bool IsAzureStackModule(String fileName)
         {
+            bool isAzureStackModule = false;
+            if (fileName.Contains("Stack"))
+            {
+                isAzureStackModule = true;
+            }
             var executingAssemblyPath = Assembly.GetExecutingAssembly().Location;
             var versionControllerDirectory = Directory.GetParent(executingAssemblyPath).FullName;
             var whiteListFile = Path.Combine(versionControllerDirectory, "WhiteList.csv");
@@ -27,12 +29,13 @@ namespace VersionController.Netcore.Utilities
                     {
                         if (fileName.Contains(cols[0]))
                         {
-                            return true;
+                            isAzureStackModule = false;
+                            break;
                         }
                     }
                 }
             }
-            return false;
+            return isAzureStackModule;
         }
     }
 }

--- a/tools/VersionController/Utilities/WhiteList.cs
+++ b/tools/VersionController/Utilities/WhiteList.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing.Drawing2D;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace VersionController.Netcore.Utilities
+{
+    class WhiteList
+    {
+        public static bool Contains(String fileName)
+        {
+            var executingAssemblyPath = Assembly.GetExecutingAssembly().Location;
+            var versionControllerDirectory = Directory.GetParent(executingAssemblyPath).FullName;
+            var whiteListFile = Path.Combine(versionControllerDirectory, "WhiteList.csv");
+            if (File.Exists(whiteListFile))
+            {
+                var lines = File.ReadAllLines(whiteListFile).Skip(1).Where(c => !string.IsNullOrEmpty(c));
+                foreach (var line in lines)
+                {
+                    var cols = line.Split(",").Select(c => c.StartsWith("\"") ? c.Substring(1) : c)
+                                              .Select(c => c.EndsWith("\"") ? c.Substring(0, c.Length - 1) : c)
+                                              .Select(c => c.Trim()).ToArray();
+                    if (cols.Length >= 1)
+                    {
+                        if (fileName.Contains(cols[0]))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/tools/VersionController/VersionController.Netcore.csproj
+++ b/tools/VersionController/VersionController.Netcore.csproj
@@ -48,9 +48,6 @@
 
   <ItemGroup>
     <Content Include="MinimalVersion.csv" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="WhiteList.csv" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tools/VersionController/VersionController.Netcore.csproj
+++ b/tools/VersionController/VersionController.Netcore.csproj
@@ -50,4 +50,8 @@
     <Content Include="MinimalVersion.csv" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="WhiteList.csv" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tools/VersionController/WhiteList.csv
+++ b/tools/VersionController/WhiteList.csv
@@ -1,2 +1,2 @@
 Module
-Az.StackEdge
+StackEdge

--- a/tools/VersionController/WhiteList.csv
+++ b/tools/VersionController/WhiteList.csv
@@ -1,0 +1,2 @@
+Module
+Az.StackEdge


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add a brief description of the changes made in this PR -->
Add whitelist to make sure bump StackEdge version correctly. Before the verioncontroller tool executes incorrectly for Az.StackEdge module because it contains preserved term "Stack". We add StackEdge to the whitelist so that it can execute correctly.
## Checklist

- [x] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [x] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [x] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] For public API changes to cmdlets:
    - [x] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [x] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
